### PR TITLE
Allow arguments to be passed to sphinx_autobuild

### DIFF
--- a/server.py
+++ b/server.py
@@ -78,7 +78,7 @@ if __name__ == '__main__':
 
         builder = sphinx_autobuild.SphinxBuilder(
             outdir=build_folder,
-            args=['-b', 'html', source_folder, build_folder],
+            args=['-b', 'html', source_folder, build_folder]+sys.argv[1:],
             ignored=ignored_files
         )
 
@@ -91,7 +91,7 @@ if __name__ == '__main__':
         server.serve(port=8000, host='0.0.0.0', root=build_folder)
     else:
         # Building once when server starts
-        builder = sphinx_autobuild.SphinxBuilder(outdir=build_folder, args=['-b', 'html', source_folder, build_folder])
+        builder = sphinx_autobuild.SphinxBuilder(outdir=build_folder, args=['-b', 'html', source_folder, build_folder]+sys.argv[1:])
         builder.build()
 
         sys.argv = ['nouser', '8000']


### PR DESCRIPTION
Allow arguments like -a, -E, -j, -v etc. to be passed through this script and into sphinx_autobuild which may use them or pass them to sphinx-build. Then the container can be invoked with a manual command to allow these flags to be used.

This change does not perform any parsing on arguments, but sphinx_autobuild has a robust command parser which should manage that, as this script takes no arguments itself