### PR TITLE
Pick up latest version of `python-livereload` package

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ MAINTAINER Quentin de Longraye <quentin@dldl.fr>
 
 RUN apk add --no-cache --virtual --update py-pip make wget ca-certificates ttf-dejavu openjdk8-jre graphviz \
     && pip install --upgrade pip \
-    && pip install sphinx sphinx_rtd_theme sphinxcontrib-plantuml sphinx_autobuild
+    && pip install livereload sphinx sphinx_rtd_theme sphinxcontrib-plantuml sphinx_autobuild
 
 RUN wget http://downloads.sourceforge.net/project/plantuml/plantuml.jar -P /opt/ \
     && echo -e '#!/bin/sh -e\njava -jar /opt/plantuml.jar "$@"' > /usr/local/bin/plantuml \

--- a/README.md
+++ b/README.md
@@ -20,7 +20,6 @@ image based on Alpine.
 
 - This image is not bundled with LaTeX but you can generate *.tex* files and
   compile them outside of the container
-- It is not possible to customize ports when autobuild is enabled
 
 ## Installation
 
@@ -79,9 +78,8 @@ Run the following command at the root of your documentation:
 docker run -itd -v "$(pwd)":/web -u $(id -u):$(id -g) -p 8000:8000 --name sphinx-server dldl/sphinx-server
 ```
 
-The web server will be listening on port `8000`. You should not change it or autobuild
-will no longer works. All the files in the current directory will be mount in the
-container.
+The web server will be listening on port `8000`.
+All the files in the current directory will be mounted in the container.
 
 ### Interacting with the server
 


### PR DESCRIPTION
Pick up latest version of `python-livereload` package (v2.6.0)
rather than the one calculated from dependencies
(v2.6.0 fixes autobuild w/ port-mapping)

Fixes issue #13