### PR TITLE
Updating the version to Python 3.8.5 on Alpine 3.12.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.8.0-alpine3.10
+FROM python:3.8.5-alpine3.12
 
 MAINTAINER Loïc Pauletto <loic.pauletto@gmail.com>
 MAINTAINER Quentin de Longraye <quentin@dldl.fr>

--- a/README.md
+++ b/README.md
@@ -65,7 +65,13 @@ also need to set `autobuild` to false.
 Run the following command at the root of your documentation:
 
 ```sh
-docker run -itd -v "$(pwd)":/web -p 8000:8000 --name sphinx-server dldl/sphinx-server
+docker run             \
+  -itd                 \
+  -v "$(pwd)":/web     \
+  -u $(id -u):$(id -g) \
+  -p 8000:8000         \
+  --name sphinx-server \
+  dldl/sphinx-server
 ```
 
 **With autobuild enabled:**
@@ -75,7 +81,13 @@ Autobuild is enabled by default. You may add folders and files to the `ignore` l
 Run the following command at the root of your documentation:
 
 ```sh
-docker run -itd -v "$(pwd)":/web -u $(id -u):$(id -g) -p 8000:8000 --name sphinx-server dldl/sphinx-server
+docker run             \
+  -itd                 \
+  -v "$(pwd)":/web     \
+  -u $(id -u):$(id -g) \
+  -p 8000:8000         \
+  --name sphinx-server \
+  dldl/sphinx-server
 ```
 
 The web server will be listening on port `8000`.


### PR DESCRIPTION
Added to README, setting user to `docker run` command when autobuild is not enabled.
Spaced out the docker run command to be a little more clear when reading.